### PR TITLE
Newspeed supports GOST-engine

### DIFF
--- a/src/apps.h
+++ b/src/apps.h
@@ -13,12 +13,23 @@ void apps_init(void);
 ENGINE *setup_engine(const char *engine, int debug);
 void release_engine(ENGINE *e);
 
-int EVP_PKEY_name_parser(int *nid, int *subparam, ENGINE **e, const char *name);
+typedef enum name_parser_enum {
+    error=-1,
+    success=0,
+    key_file=50,
+    ec_params_file,
+} name_parser_st;
+
+name_parser_st EVP_PKEY_name_parser(int *nid, int *subparam, ENGINE **e, const char **fname, const char *in_name);
 
 #define EVP_PKEY_keygen_wrapper(nid,subparam,engine) \
     _EVP_PKEY_keygen_wrapper((nid),(subparam),(engine),NULL)
 
 EVP_PKEY *_EVP_PKEY_keygen_wrapper(const int type, int arg2, ENGINE *engine, EVP_PKEY_CTX **ret_kctx);
+
+EC_GROUP *EC_GROUP_new_from_ecparams_fname(const char *fname);
+EVP_PKEY *EVP_PKEY_new_from_ecparams_fname(const char *fname);
+EVP_PKEY *EVP_PKEY_new_private_from_fname(const char *fname);
 
 size_t EVP_PKEY_get1_PublicKey(const EVP_PKEY *pkey, unsigned char **ptr);
 

--- a/src/apps_opt.c
+++ b/src/apps_opt.c
@@ -9,7 +9,7 @@
 #include "apps.h"
 #include <string.h>
 #if !defined(OPENSSL_SYS_MSDOS)
-# include OPENSSL_UNISTD
+# include <unistd.h>
 #endif
 
 #include <stdlib.h>

--- a/src/newspeed_config.h
+++ b/src/newspeed_config.h
@@ -6,7 +6,7 @@
 #define SAMPLING_MODIFIED_SUPERCOP 3
 #define SAMPLING_PERF 4
 
-#define SAMPLING SAMPLING_PERF
+#define SAMPLING SAMPLING_SUPERCOP
 
 //#define NOOP
 #define HYPERLOOP 7 // 2^HYPERLOOP iterations per sample


### PR DESCRIPTION
To measure the performance of our tool (called [ECCKiila](https://gitlab.com/nisec/ecckiila)), we have added some hacks to newspeed that allow us to get the times from `gost-engine`.

This is an example:
```console 
$ openssl genpkey -engine gost -algorithm gost2001 -pkeyopt paramset:A -out id-GostR3410-2001-CryptoPro-A-ParamSet.pem

$ ./newspeed -engine gost -evp_pkey_keygen PEM_KEY_FILE:id-GostR3410-2001-CryptoPro-A-ParamSet.pem -evp_pkey_derive PEM_KEY_FILE:id-GostR3410-2001-CryptoPro-A-ParamSet.pem -evp_pkey_sign PEM_KEY_FILE:id-GostR3410-2001-CryptoPro-A-ParamSet.pem -evp_pkey_verify PEM_KEY_FILE:id-GostR3410-2001-CryptoPro-A-ParamSet.pem
engine "gost" set.
Running 12800 times 256 bit PEM_KEY_FILE:id-GostR3410-2001-CryptoPro-A-ParamSet.pem evp_pkey_keygen... 1594022160 cycles
Running 12800 times 256 bit PEM_KEY_FILE:id-GostR3410-2001-CryptoPro-A-ParamSet.pem evp_pkey_derive... 5280393608 cycles
Running 12800 times 256 bit PEM_KEY_FILE:id-GostR3410-2001-CryptoPro-A-ParamSet.pem evp_pkey_sign... 1334006016 cycles
Running 12800 times 256 bit PEM_KEY_FILE:id-GostR3410-2001-CryptoPro-A-ParamSet.pem evp_pkey_verify... 5775121664 cycles
256 bits PEM_KEY_FILE:id-GostR3410-2001-CryptoPro-A-ParamSet spu=0,tot_var=4210841,abs_max_dev=19377,var_var=0,var_min=0,min_min=123832,median=124083,avg=124532.48,std=2052.03,rel_std=1.65%
256 bits PEM_KEY_FILE:id-GostR3410-2001-CryptoPro-A-ParamSet spu=0,tot_var=1386551369,abs_max_dev=84186,var_var=0,var_min=0,min_min=384140,median=385775,avg=412530.23,std=37236.43,rel_std=9.03%
256 bits PEM_KEY_FILE:id-GostR3410-2001-CryptoPro-A-ParamSet spu=0,tot_var=79062864,abs_max_dev=21697,var_var=0,var_min=0,min_min=92177,median=110716,avg=104218.72,std=8891.73,rel_std=8.53%
256 bits PEM_KEY_FILE:id-GostR3410-2001-CryptoPro-A-ParamSet spu=0,tot_var=1505959613,abs_max_dev=85747,var_var=0,var_min=0,min_min=399331,median=480797,avg=451180.88,std=38806.70,rel_std=8.60%
```

Where we got the performance for `key generation`, `key agreement`, `signing`, and `verifying` successfully.

Tagging @romen, @bbbrumley